### PR TITLE
feat(coverage): test coverage 도입 (Phase 1 측정 + Phase 2 래칫)

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,0 +1,9 @@
+{
+  "total": {
+    "lines":      { "pct": 68.26 },
+    "statements": { "pct": 68.10 },
+    "functions":  { "pct": 65.28 },
+    "branches":   { "pct": 55.50 }
+  },
+  "tolerance": 0.5
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
+      - name: Coverage ratchet
+        run: npm run coverage:ratchet
+
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,36 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+
+      - name: Report coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: davelosert/vitest-coverage-report-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ data/export/
 .idea/
 .omc/
 .worktrees/
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data/export/
 .mcp.json
 .idea/
 .omc/
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ interface Event {
 
 - [Ping 커맨드](docs/features/ping.md)
 - [CI 파이프라인](docs/features/ci-pipeline.md)
+- [Test Coverage 도입](docs/features/test-coverage.md)
 - [Discord 커맨드 자동 배포](docs/features/deploy-commands.md)
 - [Claude API 서비스](docs/features/claude-service.md)
 - [Discord 메시지 수집 스크립트](docs/features/fetch-messages.md)

--- a/docs/features/test-coverage.md
+++ b/docs/features/test-coverage.md
@@ -1,0 +1,80 @@
+---
+title: Test Coverage 도입
+status: implemented
+last_updated: 2026-05-12
+owner: taehyung.koo@musinsa.com
+related_spec: docs/superpowers/specs/2026-05-12-test-coverage-design.md
+---
+
+# Test Coverage 도입
+
+## 개요
+
+Vitest 기반 테스트 커버리지를 단계적으로 운영한다.
+
+- Phase 1 (가시화): 측정만, 게이팅 없음.
+- Phase 2 (래칫): `.coverage-baseline.json`을 바닥선으로 강제. 단조 증가.
+- Phase 3 (갭 필링): HTML 리포트로 핫패스를 식별해 테스트 추가.
+
+상세 설계: `docs/superpowers/specs/2026-05-12-test-coverage-design.md`
+
+## 명령어
+
+```bash
+npm run test:coverage      # 로컬에서 커버리지 측정 (콘솔 표 + coverage/index.html)
+npm run coverage:ratchet   # 현재 측정치를 baseline과 비교 (CI와 동일)
+```
+
+## 측정 범위
+
+| 포함 | 제외 |
+|---|---|
+| `src/services/**` | `src/scripts/**` |
+| `src/http/**` | `src/loaders/**` |
+| `src/utils/**` | `src/types/**` |
+| `src/db/repositories/**` | `src/index.ts`, `src/client.ts`, `src/deploy-commands.ts` |
+| `src/events/**` | `src/db/schema.ts`, `src/config.ts` |
+| `src/commands/**` | `**/*.test.ts`, `**/*.d.ts` |
+
+설정은 `vitest.config.ts`의 `test.coverage.include` / `exclude` 참조.
+Vitest 4부터 `coverage.all` 옵션은 제거됐고, `include` 패턴만으로 미실행 파일도 0%로 집계된다.
+
+## 래칫 동작
+
+- baseline 4개 메트릭(lines/statements/functions/branches) 중 하나라도 `current + tolerance < baseline`이면 CI 실패.
+- `tolerance: 0.5` (%p) — 부동소수점/마이크로 변동의 가짜 양성 방지.
+- 어느 메트릭이 +1.0%p 이상 상승하면 "baseline 상향 권장" 안내 (실패 아님).
+
+구현: `scripts/coverage-ratchet.ts` (순수 함수) + `scripts/check-coverage-ratchet.ts` (CLI). CI에서 `npm run coverage:ratchet` 호출.
+
+## baseline 갱신 운영 룰
+
+- 갱신은 **단독 PR**로만. 다른 변경과 섞지 않는다.
+- PR 본문에 갱신 사유 명시 (예: "X 모듈 테스트 추가, lines 62.4% → 67.1%").
+- 4개 메트릭을 **동시에** 갱신한다 (한 개만 올리면 나머지가 떨어진 것을 놓침).
+- **하향 금지.** 긴급 시 revert로만.
+
+## Phase 3 갭 필링 절차
+
+1. 로컬에서 `npm run test:coverage` → `coverage/index.html` 오픈.
+2. 디렉토리별/파일별로 가장 낮은 곳 식별.
+3. 우선순위:
+   - **핫패스**: `agentService.ts`, `githubOrgService.ts`, `discordChannelService.ts`, `noticeService.ts`.
+   - **외부 통합 어댑터**: GitHub/Google/Anthropic API의 오류 경로.
+   - **commands/, events/**: Discord SDK 의존이 강해 단위 테스트 효용 낮음. `docs/testing/manual-test-scenarios.md`로 보완.
+4. 테스트 추가 PR (통상 PR) → 머지 후 baseline 갱신 단독 PR.
+
+## 트러블슈팅
+
+- **PR 코멘트가 안 보임**: `test` job 로그에서 `Report coverage on PR` step 출력 확인. org의 워크플로 권한 정책 점검 (Settings → Actions → General → Workflow permissions).
+- **래칫이 가짜 양성을 일으킴**: `tolerance`를 0.5 → 1.0으로 일시 상향하지 말고, 어떤 메트릭이 흔들리는지 먼저 식별. 통상 `branches`가 가장 흔들림.
+- **새 파일 추가로 baseline 하락**: 해당 파일의 기본 테스트도 같은 PR에 포함시키거나, 측정 대상에서 제외할지 검토.
+
+## 초기 baseline (참고)
+
+- Statements: 68.10%
+- Branches: 55.50%
+- Functions: 65.28%
+- Lines: 68.26%
+
+(2026-05-12 시점. 이후 PR로 단조 상향됨.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/node": "^22.0.0",
         "@types/node-cron": "^3.0.11",
         "@types/supertest": "^7.2.0",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
@@ -60,6 +61,42 @@
         }
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -67,6 +104,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -881,12 +942,33 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1927,6 +2009,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -2179,6 +2292,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -3723,6 +3848,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3917,6 +4049,52 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -4421,6 +4599,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "consolidate-messages": "tsx src/scripts/consolidate-messages.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "coverage:ratchet": "tsx scripts/check-coverage-ratchet.ts"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "fetch-messages:prod": "NODE_ENV=prod tsx src/scripts/fetch-messages.ts",
     "consolidate-messages": "tsx src/scripts/consolidate-messages.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "lint-staged": {
     "src/**/*.ts": [
@@ -49,6 +50,7 @@
     "@types/node": "^22.0.0",
     "@types/node-cron": "^3.0.11",
     "@types/supertest": "^7.2.0",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",

--- a/scripts/check-coverage-ratchet.ts
+++ b/scripts/check-coverage-ratchet.ts
@@ -1,0 +1,57 @@
+import { readFileSync, existsSync } from "node:fs";
+import {
+  compareCoverage,
+  type CoverageBaseline,
+  type CoverageSummary,
+} from "./coverage-ratchet.js";
+
+const BASELINE_PATH = ".coverage-baseline.json";
+const SUMMARY_PATH = "coverage/coverage-summary.json";
+
+if (!existsSync(BASELINE_PATH)) {
+  console.error(`[coverage-ratchet] baseline 파일이 없음: ${BASELINE_PATH}`);
+  process.exit(2);
+}
+if (!existsSync(SUMMARY_PATH)) {
+  console.error(
+    `[coverage-ratchet] coverage 요약 파일이 없음: ${SUMMARY_PATH}. 먼저 \`npm run test:coverage\`를 실행하세요.`,
+  );
+  process.exit(2);
+}
+
+const baseline = JSON.parse(
+  readFileSync(BASELINE_PATH, "utf8"),
+) as CoverageBaseline;
+const summary = JSON.parse(
+  readFileSync(SUMMARY_PATH, "utf8"),
+) as CoverageSummary;
+const tolerance =
+  typeof baseline.tolerance === "number" ? baseline.tolerance : 0.5;
+
+const result = compareCoverage(baseline, summary, tolerance);
+
+const fmt = (n: number) => `${n.toFixed(2)}%`;
+
+if (!result.ok) {
+  console.error("[coverage-ratchet] FAIL — 다음 메트릭이 baseline보다 낮음:");
+  for (const f of result.failures) {
+    console.error(
+      `  - ${f.metric}: baseline ${fmt(f.baseline)} -> current ${fmt(
+        f.current,
+      )} (delta ${f.delta.toFixed(2)}%p, tolerance ${tolerance}%p)`,
+    );
+  }
+  console.error(
+    "테스트를 추가하거나, 의도된 변경이라면 별도 PR로 .coverage-baseline.json을 조정하세요.",
+  );
+  process.exit(1);
+}
+
+console.log("[coverage-ratchet] PASS");
+for (const s of result.suggestions) {
+  console.log(
+    `  Suggestion: ${s.metric} ${fmt(s.baseline)} -> ${fmt(
+      s.current,
+    )} (delta +${s.delta.toFixed(2)}%p). baseline 상향 PR 고려.`,
+  );
+}

--- a/scripts/coverage-ratchet.ts
+++ b/scripts/coverage-ratchet.ts
@@ -1,0 +1,47 @@
+type MetricKey = "lines" | "statements" | "functions" | "branches";
+
+export interface CoverageSummary {
+  total: Record<MetricKey, { pct: number }>;
+}
+
+export interface CoverageBaseline extends CoverageSummary {
+  tolerance?: number;
+}
+
+export interface MetricDelta {
+  metric: MetricKey;
+  baseline: number;
+  current: number;
+  delta: number;
+}
+
+export interface RatchetResult {
+  ok: boolean;
+  failures: MetricDelta[];
+  suggestions: MetricDelta[];
+}
+
+const METRICS: MetricKey[] = ["lines", "statements", "functions", "branches"];
+
+export function compareCoverage(
+  baseline: CoverageBaseline,
+  current: CoverageSummary,
+  tolerance = 0.5,
+): RatchetResult {
+  const failures: MetricDelta[] = [];
+  const suggestions: MetricDelta[] = [];
+
+  for (const metric of METRICS) {
+    const base = baseline.total[metric].pct;
+    const cur = current.total[metric].pct;
+    const delta = cur - base;
+
+    if (cur + tolerance < base) {
+      failures.push({ metric, baseline: base, current: cur, delta });
+    } else if (delta >= 1.0) {
+      suggestions.push({ metric, baseline: base, current: cur, delta });
+    }
+  }
+
+  return { ok: failures.length === 0, failures, suggestions };
+}

--- a/tests/scripts/coverageRatchet.test.ts
+++ b/tests/scripts/coverageRatchet.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { compareCoverage } from "../../scripts/coverage-ratchet.js";
+
+const baseline = {
+  total: {
+    lines: { pct: 70 },
+    statements: { pct: 70 },
+    functions: { pct: 70 },
+    branches: { pct: 60 },
+  },
+};
+
+const makeSummary = (pcts: {
+  lines: number;
+  statements: number;
+  functions: number;
+  branches: number;
+}) => ({
+  total: {
+    lines: { pct: pcts.lines },
+    statements: { pct: pcts.statements },
+    functions: { pct: pcts.functions },
+    branches: { pct: pcts.branches },
+  },
+});
+
+describe("compareCoverage", () => {
+  it("baseline과 동일하면 통과", () => {
+    const current = makeSummary({
+      lines: 70,
+      statements: 70,
+      functions: 70,
+      branches: 60,
+    });
+    const result = compareCoverage(baseline, current, 0.5);
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("tolerance 안에서 살짝 떨어지면 통과", () => {
+    const current = makeSummary({
+      lines: 69.7,
+      statements: 70,
+      functions: 70,
+      branches: 60,
+    });
+    const result = compareCoverage(baseline, current, 0.5);
+    expect(result.ok).toBe(true);
+  });
+
+  it("tolerance를 넘어 떨어지면 실패", () => {
+    const current = makeSummary({
+      lines: 69,
+      statements: 70,
+      functions: 70,
+      branches: 60,
+    });
+    const result = compareCoverage(baseline, current, 0.5);
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].metric).toBe("lines");
+  });
+
+  it("여러 메트릭이 동시에 떨어지면 모두 보고", () => {
+    const current = makeSummary({
+      lines: 60,
+      statements: 60,
+      functions: 70,
+      branches: 60,
+    });
+    const result = compareCoverage(baseline, current, 0.5);
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((f) => f.metric).sort()).toEqual([
+      "lines",
+      "statements",
+    ]);
+  });
+
+  it("1%p 이상 상승하면 suggestion에 포함", () => {
+    const current = makeSummary({
+      lines: 71.5,
+      statements: 70,
+      functions: 70,
+      branches: 60,
+    });
+    const result = compareCoverage(baseline, current, 0.5);
+    expect(result.ok).toBe(true);
+    expect(result.suggestions).toHaveLength(1);
+    expect(result.suggestions[0].metric).toBe("lines");
+  });
+
+  it("1%p 미만 상승은 suggestion에 포함되지 않음", () => {
+    const current = makeSummary({
+      lines: 70.8,
+      statements: 70,
+      functions: 70,
+      branches: 60,
+    });
+    const result = compareCoverage(baseline, current, 0.5);
+    expect(result.ok).toBe(true);
+    expect(result.suggestions).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,19 @@ export default defineConfig({
     environment: "node",
     include: ["tests/**/*.test.ts"],
     setupFiles: ["tests/setup.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "json-summary", "json"],
+      reportsDirectory: "./coverage",
+      include: [
+        "src/services/**",
+        "src/http/**",
+        "src/utils/**",
+        "src/db/repositories/**",
+        "src/events/**",
+        "src/commands/**",
+      ],
+      exclude: ["**/*.test.ts", "**/*.d.ts", "**/types/**"],
+    },
   },
 });


### PR DESCRIPTION
## Summary

- **Phase 1 (가시화)**: `@vitest/coverage-v8` 도입, `vitest.config.ts`에 coverage 블록 추가, CI에 `test` job 신설 + `davelosert/vitest-coverage-report-action`으로 PR 자동 코멘트
- **Phase 2 (래칫 게이팅)**: `.coverage-baseline.json` 커밋, `scripts/coverage-ratchet.ts` 순수 비교 함수 + `scripts/check-coverage-ratchet.ts` CLI, CI에 `coverage:ratchet` step 추가. 4개 메트릭이 baseline보다 `tolerance(0.5%p)` 이상 떨어지면 빌드 실패
- **문서**: `docs/features/test-coverage.md` LLD + CLAUDE.md 인덱스 갱신

## 초기 baseline

- Statements: 68.10%
- Branches: 55.50%
- Functions: 65.28%
- Lines: 68.26%

이 값을 머지 직후의 main과 동기화한 뒤 운영 시작.

## 측정 범위

- 포함: `src/services/`, `src/http/`, `src/utils/`, `src/db/repositories/`, `src/events/`, `src/commands/`
- 제외: `src/scripts/`, `src/loaders/`, `src/types/`, `src/index.ts`, `src/client.ts`, `src/deploy-commands.ts`, `src/db/schema.ts`, `src/config.ts`

## 설계/플랜 문서

- Spec: `docs/superpowers/specs/2026-05-12-test-coverage-design.md`
- Plan: `docs/superpowers/plans/2026-05-12-test-coverage.md`

## Test Plan

- [ ] CI `lint-and-build` 모든 매트릭스 통과 확인
- [ ] CI `test` job 통과 확인
- [ ] PR에 coverage 표 코멘트가 자동 게시됐는지 확인
- [ ] Actions 탭에서 `coverage-report` artifact 다운로드 가능 확인
- [ ] (옵션) 의도적으로 한 테스트를 `it.skip(...)`로 비활성화한 임시 PR로 `Coverage ratchet` step 실패 동작 검증
- [ ] org Workflow permissions 정책으로 PR 코멘트 step 막히지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)